### PR TITLE
add enable_dummy parameter

### DIFF
--- a/launch/miniv_description.launch.py
+++ b/launch/miniv_description.launch.py
@@ -16,29 +16,35 @@ import os
 from ament_index_python.packages import get_package_share_directory
 import launch
 from launch.actions import DeclareLaunchArgument, ExecuteProcess
-from launch.conditions import IfCondition
+from launch.conditions import IfCondition, UnlessCondition
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 import xacro
 
 from pathlib import Path
 
-share_dir_path = os.path.join(get_package_share_directory('miniv_description'))
-xacro_path = os.path.join(share_dir_path, 'urdf', 'miniv.urdf.xacro')
+
+def generate_robot_description(enable_dummy):
+    share_dir_path = os.path.join(get_package_share_directory('miniv_description'))
+    xacro_path = ""
+    if enable_dummy:
+        xacro_path = os.path.join(share_dir_path, 'urdf', 'miniv_dummy.urdf.xacro')
+    else:
+        xacro_path = os.path.join(share_dir_path, 'urdf', 'miniv_robot.urdf.xacro')
+    doc = xacro.process_file(xacro_path)
+    robot_description = {"robot_description": doc.toxml()}
+    return robot_description
 
 
 def generate_launch_description():
-    doc = xacro.process_file(xacro_path)
-    robot_description = {"robot_description": doc.toxml()}
-    robot_state_publisher = Node(
-        package='robot_state_publisher',
-        executable='robot_state_publisher',
-        output='both',
-        parameters=[robot_description])
+    enable_dummy = LaunchConfiguration('enable_dummy', default=False)
+    enable_dummy_arg = DeclareLaunchArgument(
+                'enable_dummy', default_value=enable_dummy,
+                description="if true, enable dummy mini-v.")
     view_model = LaunchConfiguration('view_model', default=False)
     view_model_arg = DeclareLaunchArgument(
                 'view_model', default_value=view_model,
-                description="if true, launch Autoware with given rviz configuration.")
+                description="if true, launch with given rviz configuration.")
     rviz = Node(
                 package='rviz2',
                 executable='rviz2',
@@ -55,22 +61,48 @@ def generate_launch_description():
     controller_config = os.path.join(
         get_package_share_directory("miniv_description"), "config", "controllers.yaml"
     )
+    robot_state_publisher = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        output='both',
+        condition=UnlessCondition(enable_dummy),
+        parameters=[generate_robot_description(False)])
     control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[robot_description, controller_config],
+        parameters=[generate_robot_description(False), controller_config],
         output={
             "stdout": "screen",
             "stderr": "screen",
         },
+        condition=UnlessCondition(enable_dummy)
+    )
+    robot_state_publisher_dummy = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        output='both',
+        condition=IfCondition(enable_dummy),
+        parameters=[generate_robot_description(True)])
+    control_node_dummy = Node(
+        package="controller_manager",
+        executable="ros2_control_node",
+        parameters=[generate_robot_description(True), controller_config],
+        output={
+            "stdout": "screen",
+            "stderr": "screen",
+        },
+        condition=IfCondition(enable_dummy)
     )
 
     return launch.LaunchDescription(
         [
             robot_state_publisher,
+            robot_state_publisher_dummy,
             view_model_arg,
+            enable_dummy_arg,
             rviz,
             control_node,
+            control_node_dummy,
             ExecuteProcess(
                 cmd=[
                     "ros2",

--- a/urdf/miniv.ros2_control.xacro
+++ b/urdf/miniv.ros2_control.xacro
@@ -1,11 +1,11 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="azimuth_thruster">
-  <xacro:macro name="azimuth_thruster_control" params="left_joint right_joint">
+  <xacro:macro name="azimuth_thruster_control" params="left_joint right_joint enable_dummy">
     <ros2_control name="azimuth_thruster_control" type="system">
       <hardware>
         <plugin>dynamixel_hardware_interface/DynamixelHardwareInterface</plugin>
         <param name="port_name">/dev/ttyUSB0</param>
         <param name="baudrate">9600</param>
-        <param name="enable_dummy">false</param>
+        <param name="enable_dummy">${enable_dummy}</param>
       </hardware>
       <joint name="${left_joint}">
         <param name="id">1</param>
@@ -22,7 +22,7 @@
     </ros2_control>
   </xacro:macro>
 
-  <xacro:macro name="main_thruster_control" params="ip_address port left_thruster_joint right_thruster_joint">
+  <xacro:macro name="main_thruster_control" params="ip_address port left_thruster_joint right_thruster_joint enable_dummy">
     <ros2_control name="main_thruster_control" type="system">
       <hardware>
         <plugin>miniv_control/MiniVHardware</plugin>
@@ -31,6 +31,7 @@
         <param name="timeout_seconds">10.0</param>
         <param name="left_thruster_joint">${left_thruster_joint}</param>
         <param name="right_thruster_joint">${right_thruster_joint}</param>
+        <param name="enable_dummy">${enable_dummy}</param>
       </hardware>
     </ros2_control>
   </xacro:macro>

--- a/urdf/miniv_dummy.urdf.xacro
+++ b/urdf/miniv_dummy.urdf.xacro
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<robot
+    name="mini-v"
+    xmlns:xacro="http://ros.org/wiki/xacro" 
+    xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+    xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+    xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface">
+
+  <link name="base_link">
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://miniv_description/model/A_MINI_POLARIS_main_r1.stl" scale="1 1 1"/>
+      </geometry>
+    </visual>
+  </link>
+
+  <xacro:include filename="$(find miniv_description)/urdf/thruster.xacro"/>
+  <xacro:thruster enable_dummy="true"/>
+</robot>

--- a/urdf/miniv_robot.urdf.xacro
+++ b/urdf/miniv_robot.urdf.xacro
@@ -5,6 +5,7 @@
     xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
     xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
     xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface">
+
   <link name="base_link">
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -15,5 +16,5 @@
   </link>
 
   <xacro:include filename="$(find miniv_description)/urdf/thruster.xacro"/>
-  <xacro:thruster control_azimuth="true"/>
+  <xacro:thruster enable_dummy="false"/>
 </robot>

--- a/urdf/thruster.xacro
+++ b/urdf/thruster.xacro
@@ -5,7 +5,7 @@
   xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
   xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface">
 
-  <xacro:macro name="thruster" params="control_azimuth thruster_ip_address='192.168.0.25' thruster_port=12345">
+  <xacro:macro name="thruster" params="enable_dummy thruster_ip_address='192.168.0.25' thruster_port=12345">
     <xacro:include filename="$(find miniv_description)/urdf/azimuth_thruster.xacro"/>
     <xacro:azimuth_thruster prefix="right" position="-0.51 -0.17 -0.17" orientation="0 0 0"/>
     <xacro:azimuth_thruster prefix="left" position="-0.51 0.17 -0.17" orientation="0 0 0"/>
@@ -15,11 +15,15 @@
     <xacro:main_thruster prefix="left" position="0.0 0.0 -0.05" orientation="0 0 3.14159265359"/>
 
     <xacro:include filename="$(find miniv_description)/urdf/miniv.ros2_control.xacro"/>
-    <xacro:azimuth_thruster_control left_joint="left_azimuth_joint" right_joint="right_azimuth_joint"/>
+    <xacro:azimuth_thruster_control 
+      left_joint="left_azimuth_joint" 
+      right_joint="right_azimuth_joint"
+      enable_dummy="${enable_dummy}"/>
 
     <xacro:main_thruster_control
+      enable_dummy="${enable_dummy}"
       ip_address="${thruster_ip_address}"
-      port="${thruster_port}" 
+      port="${thruster_port}"
       left_thruster_joint="left_thruster_joint"
       right_thruster_joint="right_thruster_joint"/>
   </xacro:macro>


### PR DESCRIPTION
Signed-off-by: Masaya Kataoka <ms.kataoka@gmail.com>

add enable_dummy arguments.

```
Arguments (pass arguments as '<name>:=<value>'):

    'view_model':
        if true, launch with given rviz configuration.
        (default: LaunchConfig('view_model'))

    'enable_dummy':
        if true, enable dummy mini-v.
        (default: LaunchConfig('enable_dummy'))
```